### PR TITLE
Add libCss Plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "tailwindcss": "^3.0.24",
         "typescript": "^4.5.4",
         "vite": "^2.9.7",
+        "vite-plugin-libcss": "^1.0.5",
         "vue-loader": "^16.8.3",
         "vue-tsc": "^0.34.7"
       }
@@ -21337,6 +21338,15 @@
         }
       }
     },
+    "node_modules/vite-plugin-libcss": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vite-plugin-libcss/-/vite-plugin-libcss-1.0.5.tgz",
+      "integrity": "sha512-NUQwWhn9j8fpRBwHeDr35a3TuRP0xvdIHtJni+3DcnPcq4Vrg+G5A3ZtCJ8y2EC83G97tBJ36svPdiIVuBEfsQ==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": "^2"
+      }
+    },
     "node_modules/vite-plugin-mdx": {
       "version": "3.5.10",
       "resolved": "https://registry.npmjs.org/vite-plugin-mdx/-/vite-plugin-mdx-3.5.10.tgz",
@@ -39308,6 +39318,13 @@
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
       }
+    },
+    "vite-plugin-libcss": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vite-plugin-libcss/-/vite-plugin-libcss-1.0.5.tgz",
+      "integrity": "sha512-NUQwWhn9j8fpRBwHeDr35a3TuRP0xvdIHtJni+3DcnPcq4Vrg+G5A3ZtCJ8y2EC83G97tBJ36svPdiIVuBEfsQ==",
+      "dev": true,
+      "requires": {}
     },
     "vite-plugin-mdx": {
       "version": "3.5.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     },
     "./dist/style.css": "./dist/style.css"
   },
-  "unpkg": "dist/kurz-components.umd.min.js",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
@@ -55,6 +54,7 @@
     "tailwindcss": "^3.0.24",
     "typescript": "^4.5.4",
     "vite": "^2.9.7",
+    "vite-plugin-libcss": "^1.0.5",
     "vue-loader": "^16.8.3",
     "vue-tsc": "^0.34.7"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,32 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import libCss from 'vite-plugin-libcss'
 
 
 const path = require('path')
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
-  build: {
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-      name: 'multiselect',
-    },
-    rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ['vue'],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: {
-          vue: 'Vue',
+    plugins: [
+        vue(),
+        libCss()
+    ],
+    build: {
+        lib: {
+            entry: path.resolve(__dirname, 'src/index.ts'),
+            name: 'multiselect',
         },
-
-      },
+        rollupOptions: {
+            // make sure to externalize deps that shouldn't be bundled
+            // into your library
+            external: ['vue'],
+            output: {
+                // Provide global variables to use in the UMD build
+                // for externalized deps
+                globals: {
+                    vue: 'Vue',
+                },
+            },
+        },
     },
-  },
 })


### PR DESCRIPTION
Added libCss plugin to automatically import style.css in the built files. This is a small quality-of-life-feature. It prevents the user from having to externally import the style sheet.